### PR TITLE
Add find query mechanic to connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "http://deepstream.io",
   "dependencies": {
-    "mongodb": "~2.2"
+    "mongodb": "~2.2",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/connector.js
+++ b/src/connector.js
@@ -157,6 +157,30 @@ Connector.prototype.find = function( collectionName, query, callback ) {
 }
 
 /**
+ * Performs find query on storage
+ *
+ * @param {String}   collectionName
+ * @param {Object}   query
+ * @param {Function} callback Will be called with null and the stored object
+ *                            for successful operations or with an error message string
+ *
+ * @private
+ * @returns {void}
+ */
+Connector.prototype.findOne = function( collectionName, query, callback ) {
+  const collection = this._getCollection( collectionName )
+  collection.findOne( query, ( err, doc ) => {
+    if ( err === null ) {
+      delete doc._id
+      delete doc.__d
+      callback( null, doc )
+    } else {
+      callback( err, null )
+    }
+  })
+}
+
+/**
  * Deletes an entry from the cache.
  *
  * @param   {String}   key

--- a/src/connector.js
+++ b/src/connector.js
@@ -170,7 +170,9 @@ Connector.prototype.find = function( collectionName, query, callback ) {
 Connector.prototype.findOne = function( collectionName, query, callback ) {
   const collection = this._getCollection( collectionName )
   collection.findOne( query, ( err, doc ) => {
-    if ( err === null ) {
+    if ( doc === null ) {
+      callback( null, null)
+    } else if ( err === null ) {
       delete doc._id
       delete doc.__d
       callback( null, doc )
@@ -178,6 +180,24 @@ Connector.prototype.findOne = function( collectionName, query, callback ) {
       callback( err, null )
     }
   })
+}
+
+/**
+ * Performs update query on storage
+ *
+ * @param {String}   collectionName
+ * @param {Object}   criteria Conditions for the documents to update
+ * @param {Object}   updateParams fields in the document to update
+ * @param {Object}   options mongo defined options for the update
+ * @param {Function} callback Will be called with null and the stored object
+ *                            for successful operations or with an error message string
+ *
+ * @private
+ * @returns {void}
+ */
+Connector.prototype.update = function( collectionName, criteria, updateParams, options, callback ) {
+  const collection = this._getCollection( collectionName )
+  collection.update( criteria, updateParams, options, callback)
 }
 
 /**


### PR DESCRIPTION
Create a wrapper function to execute find queries on MongoDB. The wrapper function require a collection name, a object of query parameters, and a callback to pass the result. The query wrapper transforms each document to reduce the depth of the document.