### PR TITLE
Fix for crash on setting a null value to the record.

### DIFF
--- a/src/transform-data.js
+++ b/src/transform-data.js
@@ -19,11 +19,15 @@ module.exports.transformValueForStorage = function ( value ) {
   var data = value._d
   delete value._d
 
-  if( data instanceof Array ) {
+  if( data instanceof Array) {
     data = {
       __dsList: data,
       __ds: value
     }
+  } else if (data === null){
+    data = {
+      __ds: value
+    }  
   } else {
     data.__ds = value
   }

--- a/src/transform-data.js
+++ b/src/transform-data.js
@@ -19,7 +19,7 @@ module.exports.transformValueForStorage = function ( value ) {
   var data = value._d
   delete value._d
 
-  if( data instanceof Array) {
+  if( data instanceof Array ) {
     data = {
       __dsList: data,
       __ds: value

--- a/test/transform-dataSpec.js
+++ b/test/transform-dataSpec.js
@@ -32,6 +32,18 @@ describe( 'Transforms outgoing data', () => {
       "__dsList": [ "John", "Smith" ]
     } )
   } )
+
+  it( 'Transforms null', () => {
+    const result = TransformData.transformValueForStorage( {
+      _d: null,
+      _v: 12
+    } )
+    expect( result ).to.deep.equal( {
+      "__ds": {
+        "_v": 12
+      },
+    } )
+  } )
 } )
 
 describe( 'Transforms incoming data', () => {


### PR DESCRIPTION
Im not sure the client should allow setting the entire record to null. When you do, Deepstream will crash on the mongo connector. 

This PR should resolve the issue and allow an empty record to be set.

If you have any questions about this, feel free to let me know.